### PR TITLE
Fix divison zero in ComputeMaxIterations

### DIFF
--- a/src/theia/solvers/sample_consensus_estimator.h
+++ b/src/theia/solvers/sample_consensus_estimator.h
@@ -225,7 +225,8 @@ int SampleConsensusEstimator<ModelEstimator>::ComputeMaxIterations(
   const double num_samples =
       ransac_params_.use_Tdd_test ? min_sample_size + 1 : min_sample_size;
 
-  const double log_prob = log(1.0 - pow(inlier_ratio, num_samples));
+  const double log_prob = log(1.0 - pow(inlier_ratio, num_samples))
+      - std::numeric_limits<double>::epsilon();
 
   // NOTE: For very low inlier ratios the number of iterations can actually
   // exceed the maximum value for an int. We need to keep this variable as a


### PR DESCRIPTION
Hey Chris,

I've noticed strange results when evaluating ransac, prosac and some custom variation of the algorithm, exiting after 100 evalutions (default RansacParam) with non satifsying inlierRatios and confidence.

Using clangs  [Division Zero Checker](http://clang-analyzer.llvm.org/available_checks.html#core_checkers) pointed to `log_prob` being zero.
This happens with low inlier ratios and  is probably due to floating point rounding errors.

Always subtracting epsilon fixes it for me.
