### PR TITLE
Shared cameras intrinsics

### DIFF
--- a/applications/build_reconstruction.cc
+++ b/applications/build_reconstruction.cc
@@ -109,7 +109,7 @@ DEFINE_string(intrinsics_to_optimize,
               "Set to control which intrinsics parameters are optimized during "
               "bundle adjustment.");
 DEFINE_bool(common_intrinsics, false,
-            "If set to true, intrinsics of all cameras will be considered common."
+            "Set to true to consider intrinsics of all cameras to be common."
             "At the moment, it is used only in bundle adjustment.");
 DEFINE_double(max_reprojection_error_pixels, 4.0,
               "Maximum reprojection error for a correspondence to be "
@@ -320,7 +320,8 @@ void AddMatchesToReconstructionBuilder(
                                 &camera_intrinsics_prior,
                                 &image_matches);
 
-  theia::CameraIntrinsicsGroupId group_id = theia::kInvalidCameraIntrinsicsGroupId;
+  theia::CameraIntrinsicsGroupId
+      group_id = theia::kInvalidCameraIntrinsicsGroupId;
   if (FLAGS_common_intrinsics)
     group_id = 0;
 
@@ -356,12 +357,13 @@ void AddImagesToReconstructionBuilder(
         << "Could not read calibration file.";
   }
 
-  theia::CameraIntrinsicsGroupId group_id = theia::kInvalidCameraIntrinsicsGroupId;
+  theia::CameraIntrinsicsGroupId
+      group_id = theia::kInvalidCameraIntrinsicsGroupId;
   if (FLAGS_common_intrinsics)
     group_id = 0;
 
   // Add images with possible calibration.
-  for (const std::string& image_file : image_files) {
+  for (const std::string &image_file : image_files) {
     std::string image_filename;
     CHECK(theia::GetFilenameFromFilepath(image_file, true, &image_filename));
 

--- a/applications/compute_two_view_geometry.cc
+++ b/applications/compute_two_view_geometry.cc
@@ -73,7 +73,8 @@ DEFINE_int32(min_num_inliers_for_valid_match, 30,
 DEFINE_bool(bundle_adjust_two_view_geometry, true,
             "Set to false to turn off 2-view BA.");
 DEFINE_bool(common_intrinsics, false,
-            "If set to true, intrinsics of cameras will be considered common in BA.");
+            "If set to true, intrinsics of cameras will be considered common "
+            " in BA.");
 
 using theia::DescriptorExtractorType;
 using theia::MatchingStrategy;
@@ -117,7 +118,8 @@ void AddImagesToReconstructionBuilder(
         << "Could not read calibration file.";
   }
 
-  theia::CameraIntrinsicsGroupId group_id = theia::kInvalidCameraIntrinsicsGroupId;
+  theia::CameraIntrinsicsGroupId
+      group_id = theia::kInvalidCameraIntrinsicsGroupId;
   if (FLAGS_common_intrinsics)
     group_id = 0;
 

--- a/applications/compute_two_view_geometry.cc
+++ b/applications/compute_two_view_geometry.cc
@@ -72,6 +72,8 @@ DEFINE_int32(min_num_inliers_for_valid_match, 30,
              "match.");
 DEFINE_bool(bundle_adjust_two_view_geometry, true,
             "Set to false to turn off 2-view BA.");
+DEFINE_bool(common_intrinsics, false,
+            "If set to true, intrinsics of cameras will be considered common in BA.");
 
 using theia::DescriptorExtractorType;
 using theia::MatchingStrategy;
@@ -115,6 +117,10 @@ void AddImagesToReconstructionBuilder(
         << "Could not read calibration file.";
   }
 
+  theia::CameraIntrinsicsGroupId group_id = theia::kInvalidCameraIntrinsicsGroupId;
+  if (FLAGS_common_intrinsics)
+    group_id = 0;
+
   // Add images with possible calibration.
   for (const std::string& image_file : image_files) {
     std::string image_filename;
@@ -124,9 +130,9 @@ void AddImagesToReconstructionBuilder(
         FindOrNull(camera_intrinsics_prior, image_filename);
     if (image_camera_intrinsics_prior != nullptr) {
       CHECK(reconstruction_builder->AddImageWithCameraIntrinsicsPrior(
-          image_file, *image_camera_intrinsics_prior));
+          image_file, *image_camera_intrinsics_prior, group_id));
     } else {
-      CHECK(reconstruction_builder->AddImage(image_file));
+      CHECK(reconstruction_builder->AddImage(image_file, group_id));
     }
   }
 

--- a/src/theia/sfm/bundle_adjustment/bundle_adjust_two_views.cc
+++ b/src/theia/sfm/bundle_adjustment/bundle_adjust_two_views.cc
@@ -73,38 +73,37 @@ void SetSolverOptions(const BundleAdjustmentOptions& options,
 // keep all intrinsics constant except for focal length by default.
 void AddCameraParametersToProblem(const bool constant_extrinsic_parameters,
                                   const bool constant_intrinsic_parameters,
-                                  double* camera_parameters,
+                                  double* camera_extrinsics,
+                                  double* camera_intrinsics,
                                   ceres::Problem* problem) {
   std::vector<int> constant_intrinsics;
 
-  // Set the extrinsics parameters to constant if desired.
-  if (constant_extrinsic_parameters) {
-    for (int i = 0; i < Camera::kExtrinsicsSize; i++) {
-      constant_intrinsics.push_back(i);
-    }
-  }
-
   // Keep focal length constant if desired.
   if (constant_intrinsic_parameters) {
-    constant_intrinsics.push_back(Camera::kExtrinsicsSize +
-                                  Camera::FOCAL_LENGTH);
+    constant_intrinsics.push_back(Camera::FOCAL_LENGTH);
   }
 
   // NOTE: We start at index 1 because the focal length was handled previously.
   for (int i = 1; i < Camera::kIntrinsicsSize; i++) {
-    constant_intrinsics.push_back(Camera::kExtrinsicsSize + i);
+    constant_intrinsics.push_back(i);
   }
 
-  if (constant_intrinsics.size() != Camera::kParameterSize) {
+  // Add extrinsics to problem
+  problem->AddParameterBlock(camera_extrinsics, Camera::kExtrinsicsSize);
+  if (constant_extrinsic_parameters)
+    problem->SetParameterBlockConstant(camera_extrinsics);
+
+  // Add intrinsics to problem
+  if (constant_intrinsics.size() != Camera::kIntrinsicsSize) {
     ceres::SubsetParameterization* subset_parameterization =
-      new ceres::SubsetParameterization(Camera::kParameterSize,
+      new ceres::SubsetParameterization(Camera::kIntrinsicsSize,
                                         constant_intrinsics);
-    problem->AddParameterBlock(camera_parameters,
-                               Camera::kParameterSize,
+    problem->AddParameterBlock(camera_intrinsics,
+                               Camera::kIntrinsicsSize,
                                subset_parameterization);
   } else {
-    problem->AddParameterBlock(camera_parameters, Camera::kParameterSize);
-    problem->SetParameterBlockConstant(camera_parameters);
+    problem->AddParameterBlock(camera_intrinsics, Camera::kIntrinsicsSize);
+    problem->SetParameterBlockConstant(camera_intrinsics);
   }
 }
 
@@ -141,26 +140,33 @@ BundleAdjustmentSummary BundleAdjustTwoViews(
   // Add the two cameras as parameter blocks.
   AddCameraParametersToProblem(true,
                                options.constant_camera1_intrinsics,
-                               camera1->mutable_parameters(),
+                               camera1->mutable_extrinsics(),
+                               camera1->mutable_intrinsics(),
                                &problem);
   AddCameraParametersToProblem(false,
                                options.constant_camera2_intrinsics,
-                               camera2->mutable_parameters(),
+                               camera2->mutable_extrinsics(),
+                               camera2->mutable_intrinsics(),
                                &problem);
-  parameter_ordering->AddElementToGroup(camera1->mutable_parameters(), 1);
-  parameter_ordering->AddElementToGroup(camera2->mutable_parameters(), 1);
+  parameter_ordering->AddElementToGroup(camera1->mutable_extrinsics(), 2);
+  parameter_ordering->AddElementToGroup(camera1->mutable_intrinsics(), 1);
+
+  parameter_ordering->AddElementToGroup(camera2->mutable_extrinsics(), 2);
+  parameter_ordering->AddElementToGroup(camera2->mutable_intrinsics(), 1);
 
   // Add triangulated points to the problem.
   for (int i = 0; i < points3d->size(); i++) {
     problem.AddResidualBlock(
         ReprojectionError::Create(correspondences[i].feature1),
         NULL,
-        camera1->mutable_parameters(),
+        camera1->mutable_extrinsics(),
+        camera1->mutable_intrinsics(),
         points3d->at(i).data());
     problem.AddResidualBlock(
         ReprojectionError::Create(correspondences[i].feature2),
         NULL,
-        camera2->mutable_parameters(),
+        camera2->mutable_extrinsics(),
+        camera2->mutable_intrinsics(),
         points3d->at(i).data());
 
     parameter_ordering->AddElementToGroup(points3d->at(i).data(), 0);

--- a/src/theia/sfm/bundle_adjustment/bundle_adjustment.cc
+++ b/src/theia/sfm/bundle_adjustment/bundle_adjustment.cc
@@ -180,8 +180,9 @@ BundleAdjustmentSummary BundleAdjustPartialReconstruction(
       continue;
     }
 
-    Camera* camera = view->MutableCamera();
-    problem.AddParameterBlock(camera->mutable_extrinsics(), Camera::kExtrinsicsSize);
+    Camera *camera = view->MutableCamera();
+    problem.AddParameterBlock(camera->mutable_extrinsics(),
+                              Camera::kExtrinsicsSize);
     // Add camera extrinsics to group 2.
     parameter_ordering->AddElementToGroup(camera->mutable_extrinsics(), 2);
 
@@ -192,13 +193,14 @@ BundleAdjustmentSummary BundleAdjustPartialReconstruction(
     if (group_id != kInvalidCameraIntrinsicsGroupId) {
       if (ContainsKey(group_representatives, group_id)) {
         ViewId leader_id = group_representatives[group_id];
-        Camera *leader_camera = reconstruction->MutableView(leader_id)->MutableCamera();
+        Camera *leader_camera =
+            reconstruction->MutableView(leader_id)->MutableCamera();
         camera_group_intrinsics = leader_camera->mutable_intrinsics();
       }
       else {
         group_representatives[group_id] = view_id;
-        // This function will add intrinsic camera parameters to the problem and will keep
-        // them constant if desired.
+        // This function will add intrinsic camera parameters to the problem
+        // and will keep them constant if desired.
         AddCameraIntrinsicsToProblem(constant_intrinsics,
                                      camera_group_intrinsics,
                                      &problem);
@@ -293,13 +295,15 @@ BundleAdjustmentSummary BundleAdjustPartialReconstruction(
       continue;
     }
     CameraIntrinsicsGroupId group_id = view->GetCameraIntrinsicsGroupId();
-    // If the view reach this code, it's group (if present) is already in group_representatives.
+    // If the view reach this code, it's group (if present) is already
+    // in group_representatives.
     if (group_id == kInvalidCameraIntrinsicsGroupId ||
         group_representatives[group_id] == view_id)
       continue;
 
     Camera *camera = view->MutableCamera();
-    const Camera &leader_camera = reconstruction->View(group_representatives[group_id])->Camera();
+    const Camera &leader_camera =
+        reconstruction->View(group_representatives[group_id])->Camera();
 
     memcpy(camera->mutable_intrinsics(),
            leader_camera.intrinsics(),

--- a/src/theia/sfm/camera/reprojection_error.h
+++ b/src/theia/sfm/camera/reprojection_error.h
@@ -46,20 +46,20 @@ struct ReprojectionError {
  public:
   explicit ReprojectionError(const Feature& feature) : feature_(feature) {}
 
-  template<typename T> bool operator()(const T* camera_parameters,
+  template<typename T> bool operator()(const T* camera_extrinsics, const T* camera_intrinsics,
                                        const T* point_parameters,
                                        T* reprojection_error) const {
     // Do not evaluate invalid camera configurations.
-    if (camera_parameters[Camera::kExtrinsicsSize + Camera::FOCAL_LENGTH] <
+    if (camera_intrinsics[Camera::FOCAL_LENGTH] <
             T(0.0) ||
-        camera_parameters[Camera::kExtrinsicsSize + Camera::ASPECT_RATIO] <
+        camera_intrinsics[Camera::ASPECT_RATIO] <
             T(0.0)) {
       return false;
     }
 
     T reprojection[2];
-    ProjectPointToImage(camera_parameters,
-                        camera_parameters + Camera::kExtrinsicsSize,
+    ProjectPointToImage(camera_extrinsics,
+                        camera_intrinsics,
                         point_parameters,
                         reprojection);
     reprojection_error[0] = reprojection[0] - T(feature_.x());
@@ -71,7 +71,8 @@ struct ReprojectionError {
     static const int kPointSize = 4;
     return new ceres::AutoDiffCostFunction<ReprojectionError,
                                            2,
-                                           Camera::kParameterSize,
+                                           Camera::kExtrinsicsSize,
+                                           Camera::kIntrinsicsSize,
                                            kPointSize>(
         new ReprojectionError(feature));
   }

--- a/src/theia/sfm/reconstruction_builder.cc
+++ b/src/theia/sfm/reconstruction_builder.cc
@@ -174,7 +174,10 @@ ReconstructionBuilder::~ReconstructionBuilder() {}
 bool ReconstructionBuilder::AddImage(const std::string &image_filepath,
                                      const CameraIntrinsicsGroupId group_id) {
   image_filepaths_.emplace_back(image_filepath);
-  if (!AddViewToReconstruction(image_filepath, NULL, group_id, reconstruction_.get())) {
+  if (!AddViewToReconstruction(image_filepath,
+                               NULL,
+                               group_id,
+                               reconstruction_.get())) {
     return false;
   }
   return feature_extractor_and_matcher_->AddImage(image_filepath);

--- a/src/theia/sfm/reconstruction_builder.cc
+++ b/src/theia/sfm/reconstruction_builder.cc
@@ -54,6 +54,7 @@ namespace {
 
 bool AddViewToReconstruction(const std::string& image_filepath,
                              const CameraIntrinsicsPrior* intrinsics,
+                             const CameraIntrinsicsGroupId group_id,
                              Reconstruction* reconstruction) {
   std::string image_filename;
   CHECK(GetFilenameFromFilepath(image_filepath, true, &image_filename));
@@ -70,6 +71,11 @@ bool AddViewToReconstruction(const std::string& image_filepath,
   if (intrinsics != nullptr) {
     View* view = reconstruction->MutableView(view_id);
     *view->MutableCameraIntrinsicsPrior() = *intrinsics;
+  }
+
+  // Add the camera intrinsics group id if available.
+  if (group_id != kInvalidCameraIntrinsicsGroupId) {
+    reconstruction->MutableView(view_id)->SetCameraIntrinsicsGroupId(group_id);
   }
   return true;
 }
@@ -165,20 +171,23 @@ ReconstructionBuilder::ReconstructionBuilder(
 
 ReconstructionBuilder::~ReconstructionBuilder() {}
 
-bool ReconstructionBuilder::AddImage(const std::string& image_filepath) {
+bool ReconstructionBuilder::AddImage(const std::string &image_filepath,
+                                     const CameraIntrinsicsGroupId group_id) {
   image_filepaths_.emplace_back(image_filepath);
-  if (!AddViewToReconstruction(image_filepath, NULL, reconstruction_.get())) {
+  if (!AddViewToReconstruction(image_filepath, NULL, group_id, reconstruction_.get())) {
     return false;
   }
   return feature_extractor_and_matcher_->AddImage(image_filepath);
 }
 
 bool ReconstructionBuilder::AddImageWithCameraIntrinsicsPrior(
-    const std::string& image_filepath,
-    const CameraIntrinsicsPrior& camera_intrinsics_prior) {
+    const std::string &image_filepath,
+    const CameraIntrinsicsPrior &camera_intrinsics_prior,
+    const CameraIntrinsicsGroupId group_id) {
   image_filepaths_.emplace_back(image_filepath);
   if (!AddViewToReconstruction(image_filepath,
                                &camera_intrinsics_prior,
+                               group_id,
                                reconstruction_.get())) {
     return false;
   }

--- a/src/theia/sfm/reconstruction_builder.h
+++ b/src/theia/sfm/reconstruction_builder.h
@@ -117,12 +117,14 @@ class ReconstructionBuilder {
   ~ReconstructionBuilder();
 
   // Add an image to the reconstruction.
-  bool AddImage(const std::string& image_filepath);
+  bool AddImage(const std::string& image_filepath,
+                const CameraIntrinsicsGroupId group_id);
 
   // Same as above, but with the camera priors manually specified.
   bool AddImageWithCameraIntrinsicsPrior(
       const std::string& image_filepath,
-      const CameraIntrinsicsPrior& camera_intrinsics_prior);
+      const CameraIntrinsicsPrior& camera_intrinsics_prior,
+      const CameraIntrinsicsGroupId group_id);
 
   // Add a match to the view graph. Either this method is repeatedly called or
   // ExtractAndMatchFeatures must be called.

--- a/src/theia/sfm/types.h
+++ b/src/theia/sfm/types.h
@@ -48,7 +48,7 @@ typedef uint32_t TrackId;
 typedef std::pair<ViewId, ViewId> ViewIdPair;
 
 static const ViewId kInvalidViewId = std::numeric_limits<ViewId>::max();
-static const ViewId kInvalidTrackId = std::numeric_limits<TrackId>::max();
+static const TrackId kInvalidTrackId = std::numeric_limits<TrackId>::max();
 
 // Used as the projection matrix type.
 typedef Eigen::Matrix<double, 3, 4> Matrix3x4d;

--- a/src/theia/sfm/types.h
+++ b/src/theia/sfm/types.h
@@ -46,9 +46,12 @@ namespace theia {
 typedef uint32_t ViewId;
 typedef uint32_t TrackId;
 typedef std::pair<ViewId, ViewId> ViewIdPair;
+typedef uint32_t CameraIntrinsicsGroupId;
 
 static const ViewId kInvalidViewId = std::numeric_limits<ViewId>::max();
 static const TrackId kInvalidTrackId = std::numeric_limits<TrackId>::max();
+static const CameraIntrinsicsGroupId kInvalidCameraIntrinsicsGroupId =
+    std::numeric_limits<CameraIntrinsicsGroupId>::max();
 
 // Used as the projection matrix type.
 typedef Eigen::Matrix<double, 3, 4> Matrix3x4d;

--- a/src/theia/sfm/view.cc
+++ b/src/theia/sfm/view.cc
@@ -46,10 +46,13 @@
 
 namespace theia {
 
-View::View() : name_(""), is_estimated_(false), camera_intrinsics_group_id_(kInvalidCameraIntrinsicsGroupId) {}
+View::View()
+    : name_(""), is_estimated_(false),
+      camera_intrinsics_group_id_(kInvalidCameraIntrinsicsGroupId) {}
 
-View::View(const std::string& name)
-    : name_(name), is_estimated_(false), camera_intrinsics_group_id_(kInvalidCameraIntrinsicsGroupId) {}
+View::View(const std::string &name)
+    : name_(name), is_estimated_(false),
+      camera_intrinsics_group_id_(kInvalidCameraIntrinsicsGroupId) {}
 
 const std::string& View::Name() const {
   return name_;
@@ -77,7 +80,8 @@ CameraIntrinsicsGroupId View::GetCameraIntrinsicsGroupId() const {
 
 void View::SetCameraIntrinsicsGroupId(const CameraIntrinsicsGroupId group_id) {
   // TODO(stoyanovd): is this check needed here?
-  CHECK(group_id != kInvalidCameraIntrinsicsGroupId) << "Could not set camera_intrinsics_group_id to invalid value.";
+  CHECK(group_id != kInvalidCameraIntrinsicsGroupId)
+    << "Could not set " << "camera_intrinsics_group_id to invalid value.";
   camera_intrinsics_group_id_ = group_id;
 }
 

--- a/src/theia/sfm/view.cc
+++ b/src/theia/sfm/view.cc
@@ -46,10 +46,10 @@
 
 namespace theia {
 
-View::View() : name_(""), is_estimated_(false) {}
+View::View() : name_(""), is_estimated_(false), camera_intrinsics_group_id_(kInvalidCameraIntrinsicsGroupId) {}
 
 View::View(const std::string& name)
-    : name_(name), is_estimated_(false) {}
+    : name_(name), is_estimated_(false), camera_intrinsics_group_id_(kInvalidCameraIntrinsicsGroupId) {}
 
 const std::string& View::Name() const {
   return name_;
@@ -69,6 +69,16 @@ const class Camera& View::Camera() const {
 
 class Camera* View::MutableCamera() {
   return &camera_;
+}
+
+CameraIntrinsicsGroupId View::GetCameraIntrinsicsGroupId() const {
+  return camera_intrinsics_group_id_;
+}
+
+void View::SetCameraIntrinsicsGroupId(const CameraIntrinsicsGroupId group_id) {
+  // TODO(stoyanovd): is this check needed here?
+  CHECK(group_id != kInvalidCameraIntrinsicsGroupId) << "Could not set camera_intrinsics_group_id to invalid value.";
+  camera_intrinsics_group_id_ = group_id;
 }
 
 const struct CameraIntrinsicsPrior& View::CameraIntrinsicsPrior() const {

--- a/src/theia/sfm/view.h
+++ b/src/theia/sfm/view.h
@@ -69,6 +69,9 @@ class View {
   const class Camera& Camera() const;
   class Camera* MutableCamera();
 
+  CameraIntrinsicsGroupId GetCameraIntrinsicsGroupId() const;
+  void SetCameraIntrinsicsGroupId(const CameraIntrinsicsGroupId group_id);
+
   const struct CameraIntrinsicsPrior& CameraIntrinsicsPrior() const;
   struct CameraIntrinsicsPrior* MutableCameraIntrinsicsPrior();
 
@@ -94,6 +97,7 @@ class View {
   std::string name_;
   bool is_estimated_;
   class Camera camera_;
+  CameraIntrinsicsGroupId camera_intrinsics_group_id_;
   struct CameraIntrinsicsPrior camera_intrinsics_prior_;
   std::unordered_map<TrackId, Feature> features_;
 };

--- a/src/theia/sfm/view_test.cc
+++ b/src/theia/sfm/view_test.cc
@@ -114,7 +114,8 @@ TEST(View, CameraIntrinsicsGroupId) {
   // Test second constructor, too.
   const std::string kName = "0";
   View view_with_name(kName);
-  EXPECT_EQ(kInvalidCameraIntrinsicsGroupId, view_with_name.GetCameraIntrinsicsGroupId());
+  EXPECT_EQ(kInvalidCameraIntrinsicsGroupId,
+            view_with_name.GetCameraIntrinsicsGroupId());
 
   // Test getter and setter.
   CameraIntrinsicsGroupId group_id = 1;

--- a/src/theia/sfm/view_test.cc
+++ b/src/theia/sfm/view_test.cc
@@ -105,4 +105,24 @@ TEST(View, TrackIds) {
   }
 }
 
+TEST(View, CameraIntrinsicsGroupId) {
+  View view;
+
+  // By default group_id is set to Invalid.
+  EXPECT_EQ(kInvalidCameraIntrinsicsGroupId, view.GetCameraIntrinsicsGroupId());
+
+  // Test second constructor, too.
+  const std::string kName = "0";
+  View view_with_name(kName);
+  EXPECT_EQ(kInvalidCameraIntrinsicsGroupId, view_with_name.GetCameraIntrinsicsGroupId());
+
+  // Test getter and setter.
+  CameraIntrinsicsGroupId group_id = 1;
+  view.SetCameraIntrinsicsGroupId(group_id);
+  EXPECT_EQ(group_id, view.GetCameraIntrinsicsGroupId());
+
+  // Impossibility to set group_id to Invalid is checked in code.
+  // Maybe this behaviour must be changed later.
+}
+
 }  // namespace theia


### PR DESCRIPTION
I have realized shared intrinsics between cameras (issue #41).
I tried to use it with groups, as you pointed in issue.

Sorry for long names of variables and for a couple of boilerplate lines (part of them are hard to make cleaner).
And I am afraid my additions stretches not very beautifully through your architecture.
Wait for your recommendations.

Supplement to questions you pointed:
- What order of element groups (for Ceres) should be better (extrinsics vs intrinsics)?

And, at the moment, I don't make intrinsics of the group leader be initialized by median values of its group.