### PR TITLE
Add weights to alignment

### DIFF
--- a/src/theia/math/graph/normalized_graph_cut_test.cc
+++ b/src/theia/math/graph/normalized_graph_cut_test.cc
@@ -50,39 +50,39 @@ namespace theia {
 //    2 ------------------------- 5
 // This should be very simple to partition.
 TEST(NormalizedGraphCut, SimpleGraph) {
-//  typedef std::pair<int, int> IntPair;
-//  std::unordered_map<std::pair<int, int>, double> edge_weights;
-//  edge_weights.emplace(IntPair(0, 1), 1000);
-//  edge_weights.emplace(IntPair(1, 2), 1000);
-//  edge_weights.emplace(IntPair(0, 3), 1000);
-//  edge_weights.emplace(IntPair(3, 4), 1000);
-//  edge_weights.emplace(IntPair(4, 5), 1000);
-//  edge_weights.emplace(IntPair(3, 5), 1000);
-//  edge_weights.emplace(IntPair(0, 3), 1);
-//  edge_weights.emplace(IntPair(1, 4), 1);
-//  edge_weights.emplace(IntPair(2, 5), 1);
-//
-//  NormalizedGraphCut<int>::Options options;
-//  NormalizedGraphCut<int> ncut(options);
-//  std::unordered_set<int> subgraph1, subgraph2;
-//  EXPECT_TRUE(ncut.ComputeCut(edge_weights, &subgraph1, &subgraph2, NULL));
-//
-//  // Make sure that the subgraphs are split properly.
-//  EXPECT_EQ(subgraph1.size(), 3);
-//  EXPECT_EQ(subgraph2.size(), 3);
-//
-//  const int node_0_subgraph = ContainsKey(subgraph1, 0) ? 1 : 2;
-//  const int node_1_subgraph = ContainsKey(subgraph1, 1) ? 1 : 2;
-//  const int node_2_subgraph = ContainsKey(subgraph1, 2) ? 1 : 2;
-//  const int node_3_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
-//  const int node_4_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
-//  const int node_5_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
-//
-//  EXPECT_EQ(node_0_subgraph, node_1_subgraph);
-//  EXPECT_EQ(node_1_subgraph, node_2_subgraph);
-//  EXPECT_EQ(node_3_subgraph, node_4_subgraph);
-//  EXPECT_EQ(node_4_subgraph, node_5_subgraph);
-//  EXPECT_NE(node_0_subgraph, node_3_subgraph);
+  typedef std::pair<int, int> IntPair;
+  std::unordered_map<std::pair<int, int>, double> edge_weights;
+  edge_weights.emplace(IntPair(0, 1), 1000);
+  edge_weights.emplace(IntPair(1, 2), 1000);
+  edge_weights.emplace(IntPair(0, 3), 1000);
+  edge_weights.emplace(IntPair(3, 4), 1000);
+  edge_weights.emplace(IntPair(4, 5), 1000);
+  edge_weights.emplace(IntPair(3, 5), 1000);
+  edge_weights.emplace(IntPair(0, 3), 1);
+  edge_weights.emplace(IntPair(1, 4), 1);
+  edge_weights.emplace(IntPair(2, 5), 1);
+
+  NormalizedGraphCut<int>::Options options;
+  NormalizedGraphCut<int> ncut(options);
+  std::unordered_set<int> subgraph1, subgraph2;
+  EXPECT_TRUE(ncut.ComputeCut(edge_weights, &subgraph1, &subgraph2, NULL));
+
+  // Make sure that the subgraphs are split properly.
+  EXPECT_EQ(subgraph1.size(), 3);
+  EXPECT_EQ(subgraph2.size(), 3);
+
+  const int node_0_subgraph = ContainsKey(subgraph1, 0) ? 1 : 2;
+  const int node_1_subgraph = ContainsKey(subgraph1, 1) ? 1 : 2;
+  const int node_2_subgraph = ContainsKey(subgraph1, 2) ? 1 : 2;
+  const int node_3_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
+  const int node_4_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
+  const int node_5_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
+
+  EXPECT_EQ(node_0_subgraph, node_1_subgraph);
+  EXPECT_EQ(node_1_subgraph, node_2_subgraph);
+  EXPECT_EQ(node_3_subgraph, node_4_subgraph);
+  EXPECT_EQ(node_4_subgraph, node_5_subgraph);
+  EXPECT_NE(node_0_subgraph, node_3_subgraph);
 }
 
 }  // namespace theia

--- a/src/theia/math/graph/normalized_graph_cut_test.cc
+++ b/src/theia/math/graph/normalized_graph_cut_test.cc
@@ -50,39 +50,39 @@ namespace theia {
 //    2 ------------------------- 5
 // This should be very simple to partition.
 TEST(NormalizedGraphCut, SimpleGraph) {
-  typedef std::pair<int, int> IntPair;
-  std::unordered_map<std::pair<int, int>, double> edge_weights;
-  edge_weights.emplace(IntPair(0, 1), 1000);
-  edge_weights.emplace(IntPair(1, 2), 1000);
-  edge_weights.emplace(IntPair(0, 3), 1000);
-  edge_weights.emplace(IntPair(3, 4), 1000);
-  edge_weights.emplace(IntPair(4, 5), 1000);
-  edge_weights.emplace(IntPair(3, 5), 1000);
-  edge_weights.emplace(IntPair(0, 3), 1);
-  edge_weights.emplace(IntPair(1, 4), 1);
-  edge_weights.emplace(IntPair(2, 5), 1);
-
-  NormalizedGraphCut<int>::Options options;
-  NormalizedGraphCut<int> ncut(options);
-  std::unordered_set<int> subgraph1, subgraph2;
-  EXPECT_TRUE(ncut.ComputeCut(edge_weights, &subgraph1, &subgraph2, NULL));
-
-  // Make sure that the subgraphs are split properly.
-  EXPECT_EQ(subgraph1.size(), 3);
-  EXPECT_EQ(subgraph2.size(), 3);
-
-  const int node_0_subgraph = ContainsKey(subgraph1, 0) ? 1 : 2;
-  const int node_1_subgraph = ContainsKey(subgraph1, 1) ? 1 : 2;
-  const int node_2_subgraph = ContainsKey(subgraph1, 2) ? 1 : 2;
-  const int node_3_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
-  const int node_4_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
-  const int node_5_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
-
-  EXPECT_EQ(node_0_subgraph, node_1_subgraph);
-  EXPECT_EQ(node_1_subgraph, node_2_subgraph);
-  EXPECT_EQ(node_3_subgraph, node_4_subgraph);
-  EXPECT_EQ(node_4_subgraph, node_5_subgraph);
-  EXPECT_NE(node_0_subgraph, node_3_subgraph);
+//  typedef std::pair<int, int> IntPair;
+//  std::unordered_map<std::pair<int, int>, double> edge_weights;
+//  edge_weights.emplace(IntPair(0, 1), 1000);
+//  edge_weights.emplace(IntPair(1, 2), 1000);
+//  edge_weights.emplace(IntPair(0, 3), 1000);
+//  edge_weights.emplace(IntPair(3, 4), 1000);
+//  edge_weights.emplace(IntPair(4, 5), 1000);
+//  edge_weights.emplace(IntPair(3, 5), 1000);
+//  edge_weights.emplace(IntPair(0, 3), 1);
+//  edge_weights.emplace(IntPair(1, 4), 1);
+//  edge_weights.emplace(IntPair(2, 5), 1);
+//
+//  NormalizedGraphCut<int>::Options options;
+//  NormalizedGraphCut<int> ncut(options);
+//  std::unordered_set<int> subgraph1, subgraph2;
+//  EXPECT_TRUE(ncut.ComputeCut(edge_weights, &subgraph1, &subgraph2, NULL));
+//
+//  // Make sure that the subgraphs are split properly.
+//  EXPECT_EQ(subgraph1.size(), 3);
+//  EXPECT_EQ(subgraph2.size(), 3);
+//
+//  const int node_0_subgraph = ContainsKey(subgraph1, 0) ? 1 : 2;
+//  const int node_1_subgraph = ContainsKey(subgraph1, 1) ? 1 : 2;
+//  const int node_2_subgraph = ContainsKey(subgraph1, 2) ? 1 : 2;
+//  const int node_3_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
+//  const int node_4_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
+//  const int node_5_subgraph = ContainsKey(subgraph1, 3) ? 1 : 2;
+//
+//  EXPECT_EQ(node_0_subgraph, node_1_subgraph);
+//  EXPECT_EQ(node_1_subgraph, node_2_subgraph);
+//  EXPECT_EQ(node_3_subgraph, node_4_subgraph);
+//  EXPECT_EQ(node_4_subgraph, node_5_subgraph);
+//  EXPECT_NE(node_0_subgraph, node_3_subgraph);
 }
 
 }  // namespace theia

--- a/src/theia/sfm/transformation/align_point_clouds.h
+++ b/src/theia/sfm/transformation/align_point_clouds.h
@@ -53,6 +53,17 @@ void AlignPointCloudsUmeyama(const std::vector<Eigen::Vector3d>& left,
                              Eigen::Matrix3d* rotation,
                              Eigen::Vector3d* translation,
                              double* scale);
+    
+/// Adds weights for each match
+/// The previous objective function E = Sum(|| yi - (c.R.xi + T ||^2) becomes
+/// Sum(wi * || yi - (c.R.xi + T ||^2)
+void AlignPointCloudsUmeyamaWithWeights(const std::vector<Eigen::Vector3d>& left,
+                                        const std::vector<Eigen::Vector3d>& right,
+                                        const std::vector<double> & weights,
+                                        Eigen::Matrix3d* rotation,
+                                        Eigen::Vector3d* translation,
+                                        double* scale);
+
 
 }  // namespace theia
 

--- a/src/theia/sfm/transformation/align_point_clouds_test.cc
+++ b/src/theia/sfm/transformation/align_point_clouds_test.cc
@@ -91,10 +91,171 @@ void UmeyamaSimpleTest() {
   ASSERT_LT(fabs(expected_scale - scale), kEpsilon);
 }
 
+/// Check with the default implementation and the expected results
+void UmeyamaWithWeigthsEqualToOne() {
+    
+    // The algorithm is fast so we can make several iterations
+    const size_t nbIterations = 50;
+    for(size_t iteration = 0; iteration < nbIterations; ++iteration){
+        size_t nb = rand() % 1000 + 4; // 4 pts required
+        std::vector<Vector3d> left(nb);
+        std::vector<double> weights(nb, 1.0);
+        
+        for(size_t i = 0; i < nb; ++i)
+            left[i] = Eigen::Vector3d::Random();
+        
+        const Matrix3d rotation_mat =
+        Eigen::AngleAxisd(DegToRad(rand() % 360), Eigen::Vector3d::Random().normalized())
+        .toRotationMatrix();
+        const Vector3d translation_vec = Eigen::Vector3d::Random();
+        // We try to avoid a scale of zero
+        const double expected_scale = std::max(0.001, std::abs(1.0 +  (rand() % 2 == 0 ? 1.0 : -1.0) * (rand() % 100)/10.0));
+        
+        // Transform the points.
+        std::vector<Vector3d> right;
+        for (size_t i = 0; i < left.size(); i++) {
+            Vector3d transformed_point =
+            expected_scale * rotation_mat * left[i] + translation_vec;
+            right.emplace_back(transformed_point);
+        }
+        
+        // Compute the similarity transformation.
+        Matrix3d rotationRef;
+        Vector3d translationRef;
+        double scaleRef;
+        AlignPointCloudsUmeyama(left, right, &rotationRef, &translationRef, &scaleRef);
+        
+        // Ensure the calculated transformation is the same as the one we set.
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                ASSERT_LT(std::abs(rotationRef(i, j) - rotation_mat(i, j)), kEpsilon);
+            }
+            ASSERT_LT(std::abs(translationRef(i) - translation_vec(i)), kEpsilon);
+        }
+        ASSERT_LT(fabs(scaleRef - expected_scale), kEpsilon);
+        
+        
+        Matrix3d rotation;
+        Vector3d translation;
+        double scale;
+        AlignPointCloudsUmeyamaWithWeights(left, right, weights, &rotation, &translation, &scale);
+        
+        // Check with the expected result
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                ASSERT_LT(std::abs(rotation(i, j) - rotation_mat(i, j)), kEpsilon);
+            }
+            ASSERT_LT(std::abs(translation(i) - translation_vec(i)), kEpsilon);
+        }
+        ASSERT_LT(fabs(scale - expected_scale), kEpsilon);
+        //
+        
+        // Check with the reference implementation
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                ASSERT_LT(std::abs(rotation(i, j) - rotationRef(i, j)), kEpsilon);
+            }
+            ASSERT_LT(std::abs(translation(i) - translationRef(i)), kEpsilon);
+        }
+        ASSERT_LT(fabs(scale - scaleRef), kEpsilon);
+        //
+    }
+}
+    
+// It is not easy to find a formula for the weights that always works
+// We need to make some statistics to see if the function works in most cases
+//
+// This test adds some noise on a given fraction of the points
+// We try to estimate the weights from the errors of the first pass (setting weights to 1)
+// We can expect that the errors are where the noise was added
+// From this first result we can set a weight for each point.
+// The weight is given by exp(-distance * distance)
+// Where distance is the distance between right[i] and s * R * left[i] + T estimated by a first pass
+// To see if the new estimation from these weights is better
+// we need to check that the new parameters are closer to the expected parameters
+void UmeyamaWithWeigthsAndNoise() {
+    
+    // Make some statistics
+    const size_t nbIterations = 1000; // 1000 is not a problem the algorith is fast
+    
+    // 15 % of noise
+    const float noiseRatio = 0.15f;
+    
+    // Percentage to consider the test succeeds (is it enough ?)
+    const float percentageToConsiderThatTheTestSucceeds = 95.0f;
+    
+    size_t succeeded = 0;
+    for(size_t iteration = 0; iteration < nbIterations; ++iteration){
+        size_t nb = rand() % 1000 + 4; // 4 pts required
+        std::vector<Vector3d> left(nb);
+        std::vector<double> weights(nb, 1.0);
+        
+        for(size_t i = 0; i < nb; ++i)
+            left[i] = Eigen::Vector3d::Random();
+        
+        const Matrix3d rotation_mat =
+        Eigen::AngleAxisd(DegToRad(rand() % 360), Eigen::Vector3d::Random().normalized())
+        .toRotationMatrix();
+        const Vector3d translation_vec = Eigen::Vector3d::Random();
+        const double expected_scale = std::max(0.001, std::abs(1.0 +  (rand() % 2 == 0 ? 1.0 : -1.0) * (rand() % 100)/10.0));
+        
+        // Transform the points.
+        std::vector<Vector3d> right;
+        for (size_t i = 0; i < left.size(); i++) {
+            Vector3d transformed_point =
+            expected_scale * rotation_mat * left[i] + translation_vec;
+            right.emplace_back(transformed_point);
+        }
+        
+        // Add noise on scale, point and translation
+        for(size_t i = 0, end = (size_t)(noiseRatio * nb); i < end; ++i){
+            size_t k = rand() % nb;
+            double noiseOnScale = std::abs(expected_scale  + std::abs((rand() % 2 == 0 ? 1.0 : -1.0) * (rand() % 100)/1000.0));
+            right[k] = noiseOnScale * rotation_mat * (left[k] + Vector3d::Random()) + translation_vec + Vector3d::Random();
+        }
+        
+        
+        // We need to find some weights
+        Matrix3d rotationRef1;
+        Vector3d translationRef1;
+        double scaleRef1;
+        AlignPointCloudsUmeyamaWithWeights(left, right, weights, &rotationRef1, &translationRef1, &scaleRef1);
+        for(size_t i = 0; i < nb; ++i){
+            double dist = (right[i] - (scaleRef1 * rotationRef1 * left[i] + translationRef1)).squaredNorm();
+            weights[i]= exp(-dist);
+        }
+        //
+        
+        Matrix3d rotationRef2;
+        Vector3d translationRef2;
+        double scaleRef2;
+        AlignPointCloudsUmeyamaWithWeights(left, right, weights, &rotationRef2, &translationRef2, &scaleRef2);
+        
+        
+        // Check if the parameters are closer to real parameters ?
+        bool conditionOnScale = (std::abs(scaleRef2 - expected_scale) < std::abs(scaleRef1 - expected_scale));
+        bool conditionOnTranslation = (translation_vec-translationRef2).norm()< (translation_vec - translationRef1).norm();
+        bool conditionOnRotation = (rotation_mat - rotationRef2).norm() < (rotation_mat - rotationRef1).norm();
+        
+        if (conditionOnScale && conditionOnTranslation && conditionOnRotation)
+            ++succeeded;
+    }
+    
+    ASSERT_LE(percentageToConsiderThatTheTestSucceeds, 100.0 * succeeded/(0.0 + nbIterations));
+}
+
 }  // namespace
 
 TEST(AlignPointCloudsUmeyama, SimpleTest) {
   UmeyamaSimpleTest();
+}
+    
+TEST(AlignPointCloudsUmeyamaWithWeights, CompareWithDefaultImplementation) {
+    UmeyamaWithWeigthsEqualToOne();
+}
+
+TEST(AlignPointCloudsUmeyamaWithWeights, WeightsAndNoise) {
+    UmeyamaWithWeigthsAndNoise();
 }
 
 }  // namespace theia


### PR DESCRIPTION
I've added a new function named AlignPointCloudsUmeyamaWithWeights in align_point_clouds.h that takes into account weights on the matching.

I've also added two test functions in align_point_clouds_test.cpp.
The first test checks if the result is the same as AlignPointCloudsUmeyama when the weights are set to 1.
The second test checks the function by adding some noise. The weights are computed from the initial errors.
 See the align_point_clouds_test.cpp for more details.