### PR TITLE
Replace ImageMagick with OpenImageIO in documentation

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -23,15 +23,17 @@ Theia relies on a number of open source libraries. Luckily, most of the will be 
 
 4. `OpenImageIO <http://www.openimageio.org/>`_ is used to read and write image files.
 
-5. `Ceres Solver <https://code.google.com/p/ceres-solver/>`_ is a library for solving non-linear least squares problems. In particular, Theia uses it for Bundle Adjustment.
+5. `OpenEXR <http://www.openexr.com/>`_ is a high dynamic-range image format used within OpenImageIO.
+
+6. `Ceres Solver <https://code.google.com/p/ceres-solver/>`_ is a library for solving non-linear least squares problems. In particular, Theia uses it for Bundle Adjustment.
 
 **NOTE**: Theia also depends on the following libraries, but they are included in the installation of Ceres so it is likely that you do not need to reinstall them.
 
 
-6. `google-glog <http://code.google.com/p/google-glog>`_ is used for error checking and logging. Ceres needs glog version 0.3.1 or later. Version 0.3 (which ships with Fedora 16) has a namespace bug which prevents Ceres from building.
+7. `google-glog <http://code.google.com/p/google-glog>`_ is used for error checking and logging. Ceres needs glog version 0.3.1 or later. Version 0.3 (which ships with Fedora 16) has a namespace bug which prevents Ceres from building.
 
 
-7. `gflags <http://code.google.com/p/gflags>`_ is a library for processing command line flags. It is used by some of the examples and tests.
+8. `gflags <http://code.google.com/p/gflags>`_ is a library for processing command line flags. It is used by some of the examples and tests.
 
 
 Make sure all of these libraries are installed properly before proceeding. Improperly installing any of these libraries can cause Theia to not build.

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -21,7 +21,7 @@ Theia relies on a number of open source libraries. Luckily, most of the will be 
 
 3. `eigen3 <http://eigen.tuxfamily.org/index.php?title=Main_Page>`_ is used extensively for doing nearly all the matrix and linear algebra operations.
 
-4. `ImageMagick <http://www.imagemagick.org/>`_ is used to read and write image files.
+4. `OpenImageIO <http://www.openimageio.org/>`_ is used to read and write image files.
 
 5. `Ceres Solver <https://code.google.com/p/ceres-solver/>`_ is a library for solving non-linear least squares problems. In particular, Theia uses it for Bundle Adjustment.
 


### PR DESCRIPTION
OpenImageIO has been introduced as an external dependency in 5eb2b96 and replaced CImg which depended on ImageMagick.