### PR TITLE
Mask feature (PR#111) - copy

### DIFF
--- a/src/theia/sfm/feature_extractor_and_matcher.h
+++ b/src/theia/sfm/feature_extractor_and_matcher.h
@@ -91,6 +91,12 @@ class FeatureExtractorAndMatcher {
   bool AddImage(const std::string& image_filepath,
                 const CameraIntrinsicsPrior& intrinsics);
 
+  // Assignes a mask to an image.
+  // The mask is a black and white image, where black is 0.0 and white is 1.0.
+  // The white part of the mask indicates the area for the keypoints extraction.
+  bool AddMaskForFeaturesExtraction(const std::string& image_filepath,
+                                    const std::string& mask_filepath);
+
   // Performs feature matching between all images provided by the image
   // filepaths. Features are extracted and matched between the images according
   // to the options passed in. Only matches that have passed geometric
@@ -107,10 +113,11 @@ class FeatureExtractorAndMatcher {
 
   const Options options_;
 
-  // Local copies of the images to be matches and any priors on the camera
-  // intrinsics.
+  // Local copies of the images to be matches, masks for use and any priors on
+  // the camera intrinsics.
   std::vector<std::string> image_filepaths_;
   std::unordered_map<std::string, CameraIntrinsicsPrior> intrinsics_;
+  std::unordered_map<std::string, std::string> image_masks_;
 
   // Exif reader for loading exif information. This object is created once so
   // that the EXIF focal length database does not have to be loaded multiple

--- a/src/theia/sfm/reconstruction_builder.cc
+++ b/src/theia/sfm/reconstruction_builder.cc
@@ -231,6 +231,15 @@ void ReconstructionBuilder::RemoveUncalibratedViews() {
   }
 }
 
+bool ReconstructionBuilder::AddMaskForFeaturesExtraction(
+    const std::string& image_filepath,
+    const std::string& mask_filepath) {
+  feature_extractor_and_matcher_->AddMaskForFeaturesExtraction(
+      image_filepath,
+      mask_filepath);
+  return true;
+}
+
 bool ReconstructionBuilder::ExtractAndMatchFeatures() {
   CHECK_EQ(view_graph_->NumViews(), 0) << "Cannot call ExtractAndMatchFeatures "
                                           "after TwoViewMatches has been "

--- a/src/theia/sfm/reconstruction_builder.h
+++ b/src/theia/sfm/reconstruction_builder.h
@@ -147,6 +147,10 @@ class ReconstructionBuilder {
                        const std::string& image2,
                        const ImagePairMatch& matches);
 
+  // Assignes a mask to an image to indicate the area for keypoints extraction.
+  bool AddMaskForFeaturesExtraction(const std::string& image_filepath,
+                                    const std::string& mask_filepath);
+
   // Extracts features and performs matching with geometric verification.
   bool ExtractAndMatchFeatures();
 


### PR DESCRIPTION
Hi,
Here is a new pull request with one commit only!
(I had some difficulties with rebasing... ^^)

I hope this is ok for you.

Cheers, 


____________________________________________________________________
First modifications of theia (mask)
[Masks] 'FLAGS_masks' creation.
The label '--masks=' is usable in command line or in the 'build_reconstruction_flags.txt' file.

[Masks] Declare 'mask_filepaths_' and 'SetMasksForFeaturesExtraction()' in feature_enxtractor_and_matcher.h.

[Masks] Implement the function 'ExtractFeaturesWithMask()' and the method 'SetMasksForFeatureExtraction()' (calling 'ExtractFeaturesWithMask()') in feature_extractor_and_matcher.cc.

[Masks] Implement the 'SetMasksForFeaturesExtraction()' method in the 'ReconstructionBuilder' class.

[Masks] Modify the 'AddImageToReconstructionBuilder()' function taking in count the masks.

[Masks] BugFix: Considering the masks being GrayScaled (i.e. pxl value = [0.;1.]), the condition to remove a keypoint is no longer "==0" but "<0.5". Avoid the possible issues with artefacts due to the compression (e.g. JPEG format).

[Masks] BugFix: the flag '--masks' can be empty.

[Masks] BugFix: An error occures when the masks' format (given in the flag '--masks') is wrong.

fail

Change-Id: I5784591cd90bb950dc1971986ccedd5789f11155

fixed

Change-Id: I76984e5f9dcbf939b112e0174f2ebe610f0a2bcd

1st review
[Masks] Minor changes: identation & characters wide limit.

[Masks] Use a call by reference for the vector of image masks name in 'SetMasksForFeatureExtraction()'.

[Masks] Change the way to remove the extension to the filename.

[Masks] Merger of the functions 'Extractfeatures()' and 'ExtractFeaturesWithWithMask()'.

2nd review
[Masks] Modify the parameter 'imagemask_filepath' in the ExtractFeatures() function.

[Masks]  Correction of the 'ExtractFeatures()' function.

[Masks] Add const, remove useless lines, respect the 80 chars limit.

[Masks] Use an 'std::undorered_map' to store the masks.

[Masks] Minor changes.

3rd review
[Masks] Change the comment of the  'AddMaskForFeaturesExtraction' function.

[Mask] Simplify the mask usage from 'build_reconstructions'.

4st review
[Mask] Modify comments.

[Masks] Modify comments & Add 'break' in an if statement.