### PR TITLE
 Redundant call to OrderViewPairsByInitializationCriterion in incremental sfm

### DIFF
--- a/src/theia/sfm/incremental_reconstruction_estimator.cc
+++ b/src/theia/sfm/incremental_reconstruction_estimator.cc
@@ -325,11 +325,6 @@ bool IncrementalReconstructionEstimator::ChooseInitialViewPair() {
     return false;
   }
 
-  // Find the k view pairs that contain the highest number of verified matches
-  // and contain a sufficient baseline between them.
-  OrderViewPairsByInitializationCriterion(kMinNumInitialTracks,
-                                          &candidate_initial_view_pairs);
-
   // Try to initialize the reconstruction from the candidate view pairs. An
   // initial seed is only considered valid if the baseline relative to the 3D
   // point depths is sufficient. This robustness is measured by the angle of all


### PR DESCRIPTION
Hello,

It seems to me that there when choosing an initial view pair for incremental SfM the set of view pairs is filled two times. The commit 3777266ba68444a61621d9d8ccddf932441607d0 changed the criterion for choosing the initial view pair.

In ChooseInitialViewPair it seems the construction of the view pairs vector was done in two times, first getting suitable pairs, and then ordering them. The new function OrderViewPairsByInitializationCriterion does both at the same time, so I think it should be called only one time.

Specific change was here: https://github.com/sweeneychris/TheiaSfM/commit/3777266ba68444a61621d9d8ccddf932441607d0#diff-d9bee0872c2f1a2607990327320ac7a0R303

Note that I'm not able to build nor run at the moment, so this is solely based on code source observation.
