### PR TITLE
Fix 'pthread_mutex_try_lock' problem when compiling AKAZE

### DIFF
--- a/libraries/akaze/CMakeLists.txt
+++ b/libraries/akaze/CMakeLists.txt
@@ -105,7 +105,7 @@ TARGET_LINK_LIBRARIES(akaze_features akaze ${CIMG_LIBRARIES})
 
 # Demo program matching akaze features.
 ADD_EXECUTABLE(akaze_match akaze_match.cpp)
-TARGET_LINK_LIBRARIES(akaze_match akaze ${CIMG_LIBRARIES})
+TARGET_LINK_LIBRARIES(akaze_match akaze ${CIMG_LIBRARIES} pthread)
 
 install(TARGETS akaze
   EXPORT  TheiaExport


### PR DESCRIPTION
Fix 'pthread_mutex_try_lock' problem when compiling AKAZE by adding 'pthread' to linker

Change-Id: Ibcd11ec1f23ad8ba4c52f7714a1a8f2975a5e453