### PR TITLE
Add header for newer compiler.

### DIFF
--- a/src/theia/util/lru_cache.h
+++ b/src/theia/util/lru_cache.h
@@ -42,6 +42,7 @@
 #include <mutex>  // NOLINT
 #include <unordered_map>
 #include <utility>
+#include <functional>
 
 #include "theia/util/map_util.h"
 #include "theia/util/util.h"


### PR DESCRIPTION

 * This tiny fix amke newer gcc 7 happy. See error below:

```
/home/cbalint/work/TheiaSfM/src/theia/util/lru_cache.h:70:23: error: ‘function’ in namespace ‘std’ does not name a template type
   LRUCache(const std::function<ValueType(const KeyType&)>& fetch_entry,
```