### PR TITLE
namespace "thrust" has no member "gather"

### DIFF
--- a/libraries/flann/src/cpp/flann/algorithms/kdtree_cuda_3d_index.cu
+++ b/libraries/flann/src/cpp/flann/algorithms/kdtree_cuda_3d_index.cu
@@ -33,6 +33,7 @@
 // #define THRUST_DEBUG 1
 #include <cuda.h>
 #include <thrust/copy.h>
+#include <thrust/gather.h>
 #include <thrust/device_vector.h>
 #include <vector_types.h>
 #include <flann/util/cutil_math.h>


### PR DESCRIPTION
The above error occurs when building TheiaSfM with CUDA 9.1 on Ubuntu16.04