### PR TITLE
Compatibility with ceres-solver v1.14

### DIFF
--- a/src/theia/sfm/bundle_adjustment/bundle_adjust_two_views.cc
+++ b/src/theia/sfm/bundle_adjustment/bundle_adjust_two_views.cc
@@ -61,7 +61,6 @@ void SetSolverOptions(const BundleAdjustmentOptions& options,
   solver_options->visibility_clustering_type = ceres::CANONICAL_VIEWS;
   solver_options->logging_type = ceres::SILENT;
   solver_options->num_threads = options.num_threads;
-  solver_options->num_linear_solver_threads = options.num_threads;
   solver_options->max_num_iterations = 200;
   // Solver options takes ownership of the ordering so that we can order the BA
   // problem by points and cameras.

--- a/src/theia/sfm/bundle_adjustment/bundle_adjuster.cc
+++ b/src/theia/sfm/bundle_adjustment/bundle_adjuster.cc
@@ -63,7 +63,6 @@ void SetSolverOptions(const BundleAdjustmentOptions& options,
   solver_options->logging_type =
       options.verbose ? ceres::PER_MINIMIZER_ITERATION : ceres::SILENT;
   solver_options->num_threads = options.num_threads;
-  solver_options->num_linear_solver_threads = options.num_threads;
   solver_options->max_num_iterations = options.max_num_iterations;
   solver_options->max_solver_time_in_seconds =
       options.max_solver_time_in_seconds;

--- a/src/theia/sfm/global_pose_estimation/nonlinear_position_estimator.cc
+++ b/src/theia/sfm/global_pose_estimation/nonlinear_position_estimator.cc
@@ -134,7 +134,6 @@ bool NonlinearPositionEstimator::EstimatePositions(
   // Set the solver options.
   ceres::Solver::Summary summary;
   solver_options_.num_threads = options_.num_threads;
-  solver_options_.num_linear_solver_threads = options_.num_threads;
   solver_options_.max_num_iterations = options_.max_num_iterations;
 
   // Choose the type of linear solver. For sufficiently large problems, we want


### PR DESCRIPTION
Small fix for ceres-solver 1.14. In particular this removes the use of `Solver::Options::num_linear_solver_threads` which is deprecated in the latest version of Ceres. For more information, see the Ceres changelog: http://ceres-solver.org/version_history.html#backward-incompatible-api-changes