### PR TITLE
Fix pairwise rotation error

### DIFF
--- a/src/theia/sfm/global_pose_estimation/pairwise_rotation_error.h
+++ b/src/theia/sfm/global_pose_estimation/pairwise_rotation_error.h
@@ -68,21 +68,28 @@ bool PairwiseRotationError::operator() (const T* rotation1,
                                         T* residuals) const {
   // Convert angle axis rotations to rotation matrices.
   Eigen::Matrix<T, 3, 3> rotation1_mat, rotation2_mat;
+  Eigen::Matrix3d relative_rotation_mat;
   ceres::AngleAxisToRotationMatrix(
       rotation1, ceres::ColumnMajorAdapter3x3(rotation1_mat.data()));
   ceres::AngleAxisToRotationMatrix(
       rotation2, ceres::ColumnMajorAdapter3x3(rotation2_mat.data()));
+  ceres::AngleAxisToRotationMatrix(relative_rotation_.data(),
+      ceres::ColumnMajorAdapter3x3(relative_rotation_mat.data()));
 
   // Compute the loop rotation from the two global rotations.
   const Eigen::Matrix<T, 3, 3> loop_rotation_mat =
       rotation2_mat * rotation1_mat.transpose();
-  Eigen::Matrix<T, 3, 1> loop_rotation;
+  // Compute the error matrix between the expected relative rotation and the
+  // observed relative rotation
+  const Eigen::Matrix<T, 3, 3> error_rotation_mat =
+      loop_rotation_mat * relative_rotation_mat.cast<T>().transpose();
+  Eigen::Matrix<T, 3, 1> error_rotation;
   ceres::RotationMatrixToAngleAxis(
-      ceres::ColumnMajorAdapter3x3(loop_rotation_mat.data()),
-      loop_rotation.data());
-  residuals[0] = weight_ * (loop_rotation(0) - relative_rotation_[0]);
-  residuals[1] = weight_ * (loop_rotation(1) - relative_rotation_[1]);
-  residuals[2] = weight_ * (loop_rotation(2) - relative_rotation_[2]);
+      ceres::ColumnMajorAdapter3x3(error_rotation_mat.data()),
+      error_rotation.data());
+  residuals[0] = weight_ * error_rotation(0);
+  residuals[1] = weight_ * error_rotation(1);
+  residuals[2] = weight_ * error_rotation(2);
 
   return true;
 }

--- a/src/theia/sfm/global_pose_estimation/pairwise_rotation_error_test.cc
+++ b/src/theia/sfm/global_pose_estimation/pairwise_rotation_error_test.cc
@@ -54,7 +54,6 @@ void PairwiseRotationErrorTest(const Matrix3d& relative_rot_mat,
                                const double weight,
                                const Matrix3d& global_rot_1_mat,
                                const Matrix3d& global_rot_2_mat) {
-  // Convert matrices to angle-axis.
   Vector3d relative_rot, rotation1, rotation2;
   ceres::RotationMatrixToAngleAxis(relative_rot_mat.data(),
                                    relative_rot.data());
@@ -64,9 +63,12 @@ void PairwiseRotationErrorTest(const Matrix3d& relative_rot_mat,
   // Compute ground truth angular error.
   const AngleAxisd loop_rotation(global_rot_2_mat *
                                  global_rot_1_mat.transpose());
+  const Matrix3d gt_rotation_error_mat = loop_rotation * relative_rot_mat.transpose();
 
-  const Vector3d gt_rotation_error =
-      weight * (loop_rotation.angle() * loop_rotation.axis() - relative_rot);
+  // Convert matrices to angle-axis.
+  Vector3d gt_rotation_error;
+  ceres::RotationMatrixToAngleAxis(gt_rotation_error_mat.data(), gt_rotation_error.data());
+  gt_rotation_error *= weight;
 
   // Initialize error function and compute rotation error.
   const PairwiseRotationError global_rotation_error(relative_rot, weight);
@@ -111,12 +113,14 @@ TEST(PairwiseRotationError, NontrivialRotation) {
 TEST(PairwiseRotationError, OneHundredEightyDegreeRotation) {
   const Matrix3d global_rot_1_mat = Matrix3d::Identity();
   const Matrix3d global_rot_2_mat =
-      AngleAxisd(DegToRad(180.0), Vector3d::UnitZ()).toRotationMatrix();
-  const Matrix3d relative_rot =
       AngleAxisd(DegToRad(179.0), Vector3d::UnitZ()).toRotationMatrix();
+  const Matrix3d relative_rot =
+      AngleAxisd(DegToRad(-179.0), Vector3d::UnitZ()).toRotationMatrix();
 
   PairwiseRotationErrorTest(relative_rot, kRelativeRotationWeight,
                             global_rot_1_mat, global_rot_2_mat);
+  PairwiseRotationErrorTest(relative_rot, kRelativeRotationWeight,
+                            global_rot_2_mat, global_rot_1_mat);
 }
 
 TEST(PairwiseRotationError, Weight) {


### PR DESCRIPTION
Previously given two angle axis rotations nearly 180degs apart the error
function may have returned a large error rather than a small error. This
fixes that.

Change-Id: I240dafdf699ee048120282166a8f0d2ea9646be5