### PR TITLE
Fixed a build error when building a shared library with -fPIC.

### DIFF
--- a/src/theia/math/matrix/linear_operator.h
+++ b/src/theia/math/matrix/linear_operator.h
@@ -46,7 +46,7 @@ namespace theia {
 // www.ceres-solver.org
 class LinearOperator {
  public:
-  virtual ~LinearOperator();
+  virtual ~LinearOperator()=default;
 
   // y = y + Ax;
   virtual void RightMultiply(const Eigen::VectorXd& x,


### PR DESCRIPTION
Building a shared library with -DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON cmake options results in the following symbol being missing:
LinearOperator::~LinearOperator();

