### PR TITLE
Fixed double computation of denominator in div undist model.

### DIFF
--- a/src/theia/sfm/camera/division_undistortion_camera_model.h
+++ b/src/theia/sfm/camera/division_undistortion_camera_model.h
@@ -282,7 +282,7 @@ void DivisionUndistortionCameraModel::DistortPoint(
     distorted_point[0] = undistorted_point[0];
     distorted_point[1] = undistorted_point[1];
   } else {
-    const T scale = (1.0 - ceres::sqrt(inner_sqrt)) / (2.0 * k * r_u_sq);
+    const T scale = (1.0 - ceres::sqrt(inner_sqrt)) / denom;
     distorted_point[0] = undistorted_point[0] * scale;
     distorted_point[1] = undistorted_point[1] * scale;
   }


### PR DESCRIPTION
Change-Id: I65f8c8699b7d9fd3499aadc5f5a49a639767feb4

Fixes the double computation of the denominator in the division undistortion camera model.