### PR TITLE
Add C++14 Standard specification for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ if (EIGEN_FOUND)
   message("-- Found Eigen version ${EIGEN_VERSION}: ${EIGEN_INCLUDE_DIRS}")
 endif (EIGEN_FOUND)
 
+# Use C++14 as the standard for compilation
+set(CMAKE_CXX_STANDARD 14)
+
 # Use a larger inlining threshold for Clang, since it hobbles Eigen,
 # resulting in an unreasonably slow version of the blas routines. The
 # -Qunused-arguments is needed because CMake passes the inline


### PR DESCRIPTION
CMake C++14 Standard has been set in the root `CMakeLists.txt` file.
This currently fixes issues related to compilation errors when trying to use newer C++ members with compilers such as g++ 11.2.0.

No functional changes are involved in the current proposed solution, so this merge should not affect the software behavior.