### PR TITLE
Fix if-elseif-else structure in CMake file

### DIFF
--- a/cmake/TheiaConfig.cmake.in
+++ b/cmake/TheiaConfig.cmake.in
@@ -43,7 +43,7 @@ macro(THEIA_REPORT_NOT_FOUND REASON_MSG)
   # use the camelcase library name, not uppercase.
   if (Theia_FIND_QUIETLY)
     message(STATUS "Failed to find Theia - " ${REASON_MSG} ${ARGN})
-  else (Theia_FIND_REQUIRED)
+  elseif (Theia_FIND_REQUIRED)
     message(FATAL_ERROR "Failed to find Theia - " ${REASON_MSG} ${ARGN})
   else()
     # Neither QUIETLY nor REQUIRED, use SEND_ERROR which emits an error


### PR DESCRIPTION
The proposed change fixes the CMake inclusion of the Theia library for projects.
The current version of the file includes an `if-else-else` structure, which must be replaced with an `if-elseif-else` structure instead.