### PR TITLE
Fix vlfeat CMAKE module path

### DIFF
--- a/libraries/vlfeat/CMakeLists.txt
+++ b/libraries/vlfeat/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(vlfeat)
 
-include("${CMAKE_MODULE_PATH}/OptimizeTheiaCompilerFlags.cmake")
+include("${CMAKE_SOURCE_DIR}/cmake/OptimizeTheiaCompilerFlags.cmake")
 optimizetheiacompilerflags()
 
 include_directories(./vl)


### PR DESCRIPTION
The proposed fix solves the issue when multiple module paths are found for CMAKE. In this sense, `${CMAKE_SOURCE_DIR}` is preferred, as it always points to a unique path.