### PR TITLE
bugfix for akaze compile error issue 267

### DIFF
--- a/libraries/akaze/src/nldiffusion_functions.cpp
+++ b/libraries/akaze/src/nldiffusion_functions.cpp
@@ -253,7 +253,7 @@ void halfsample_image(const RowMatrixXf& src, RowMatrixXf& dst) {
     // Compute the row resize first.
     const int y = static_cast<int>(y_kernel_size * i);
     y_kernel_mul(0) = 1 - (y_kernel_size * i - y);
-    y_kernel_mul(y_kernel_clamped_size - 1) -=
+    y_kernel_mul(static_cast<int>(y_kernel_clamped_size - 1)) -=
         y_kernel_mul.sum() - y_kernel_size;
 
     temp_row =
@@ -264,7 +264,7 @@ void halfsample_image(const RowMatrixXf& src, RowMatrixXf& dst) {
     for (int j = 0; j < dst.cols(); j++) {
       const int x = static_cast<int>(x_kernel_size * j);
       x_kernel_mul(0) = 1 - (x_kernel_size * j - x);
-      x_kernel_mul(x_kernel_clamped_size - 1) -=
+      x_kernel_mul(static_cast<int>(x_kernel_clamped_size - 1)) -=
           x_kernel_mul.sum() - x_kernel_size;
       dst(i, j) =
           x_kernel_mul.dot(temp_row.segment(x, x_kernel_clamped_size));


### PR DESCRIPTION
Change-Id: Icd675387f35faf399541721bd7b50e9e906b3582

Fix for Issue 267 https://github.com/sweeneychris/TheiaSfM/issues/267.
Add static casts to fix indexing into Eigen vector with a float index.